### PR TITLE
Add sample urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "test-my-api",
-  "version": "1.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "test-my-api",
-      "version": "1.0.0",
+      "version": "2.2.0",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
+        "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.10.17",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3182,6 +3183,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.11.0.tgz",
+      "integrity": "sha512-I2LaOKqO8a0xcLGtIozC9xoXjZAto5G5gh0FYUMAlbsIHNHIjn4Xrw9rvjY20vZonyiGrZNMAlAXYkY6JvhF6A==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {
@@ -19689,6 +19715,14 @@
       "version": "5.10.17",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.17.tgz",
       "integrity": "sha512-iNwUuMA30nrN0tiEkeD3zaczv7Tk2jlZIDbXRnijAsYXkZtl/xEzQsVRIPYRDuyEz6D18vQJhV8h7gPUXEubTg=="
+    },
+    "@mui/icons-material": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.11.0.tgz",
+      "integrity": "sha512-I2LaOKqO8a0xcLGtIozC9xoXjZAto5G5gh0FYUMAlbsIHNHIjn4Xrw9rvjY20vZonyiGrZNMAlAXYkY6JvhF6A==",
+      "requires": {
+        "@babel/runtime": "^7.20.6"
+      }
     },
     "@mui/material": {
       "version": "5.10.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-my-api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.10.17",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import UrlSubmitter from "./components/UrlSubmitter";
 import ProxySelector from "./components/ProxySelector";
 import HeadingText from "./components/HeadingText";
 import AboutText from "./components/AboutText";
+import SampleUrls from "./components/SampleUrls";
 import "./App.css";
 
 function App() {
@@ -12,6 +13,7 @@ function App() {
     <div className="App">
       <HeadingText />
       <AboutText />
+      <SampleUrls />
       <UrlSubmitter proxyUrl={proxyUrl} />
       <UrlSubmitter proxyUrl={proxyUrl} />
       <UrlSubmitter proxyUrl={proxyUrl} />

--- a/src/components/SampleUrls.tsx
+++ b/src/components/SampleUrls.tsx
@@ -34,8 +34,10 @@ function SampleUrls() {
       <Typography variant="h6" component="h6" sx={headingStyle}>
         Sample API endpoints for testing
       </Typography>
-      <SingleUrl url={POSTMAN_GET} />
-      <SingleUrl url={POSTMAN_POST} />
+      <Box sx={endpointsWrapper}>
+        <SingleUrl url={POSTMAN_GET} />
+        <SingleUrl url={POSTMAN_POST} />
+      </Box>
       <Snackbar
         open={showCopyAlert}
         onClose={() => setShowCopyAlert(false)}
@@ -54,10 +56,20 @@ const sampleWrapper = {
   display: "flex",
   flexDirection: "column",
   width: "100%",
+  marginBottom: "25px",
 };
 
 const headingStyle = {
   width: "100%",
+};
+
+const endpointsWrapper = {
+  border: "1px solid #5b5653",
+  borderRadius: "10px",
+  background: "#e9e3e0",
+  marginBottom: "10px",
+  padding: "8px 8px 3px 8px",
+  maxWidth: "280px",
 };
 
 /* Below styles are for <SingleUrl/> helper component. */
@@ -71,7 +83,6 @@ const urlWrapper = {
   display: "flex",
   flexDirection: "row",
   justifyContent: "space-between",
-  maxWidth: "280px",
   marginBottom: "5px",
 };
 

--- a/src/components/SampleUrls.tsx
+++ b/src/components/SampleUrls.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import { Box, Typography, Snackbar, Alert } from "@mui/material";
+import { POSTMAN_GET, POSTMAN_POST } from "../util/urls";
+
+function SampleUrls() {
+  const [showCopyAlert, setShowCopyAlert] = useState(false);
+
+  // Helper function to return a URL and copy icon.
+  function SingleUrl(props: any) {
+    const { url } = props;
+
+    function handleClick() {
+      setShowCopyAlert(true);
+      navigator.clipboard.writeText(url);
+    }
+
+    return (
+      <Box sx={urlWrapper}>
+        <Typography variant="body1" component="span" sx={urlStyle}>
+          {url}
+        </Typography>
+        <ContentCopyIcon
+          onClick={handleClick}
+          color="primary"
+          sx={copyIconStyle}
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={sampleWrapper}>
+      <Typography variant="h6" component="h6" sx={headingStyle}>
+        Sample API endpoints for testing
+      </Typography>
+      <SingleUrl url={POSTMAN_GET} />
+      <SingleUrl url={POSTMAN_POST} />
+      <Snackbar
+        open={showCopyAlert}
+        onClose={() => setShowCopyAlert(false)}
+        autoHideDuration={3000}>
+        <Alert severity="info" variant="outlined">
+          Copied to clipboard
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}
+
+export default SampleUrls;
+
+const sampleWrapper = {
+  display: "flex",
+  flexDirection: "column",
+  width: "100%",
+};
+
+const headingStyle = {
+  width: "100%",
+};
+
+/* Below styles are for <SingleUrl/> helper component. */
+
+const urlStyle = {
+  fontSize: "18px",
+  opacity: "70%",
+};
+
+const urlWrapper = {
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "space-between",
+  maxWidth: "280px",
+  marginBottom: "5px",
+};
+
+const copyIconStyle = {
+  cursor: "pointer",
+};

--- a/src/util/urls.ts
+++ b/src/util/urls.ts
@@ -3,3 +3,7 @@
 // CORS-Anywhere reverse proxy URLs that users can prepend to requests.
 export const FIREBASE_PROXY = "https://proxy-ibmasyzzya-uc.a.run.app/";
 export const FLY_PROXY = "https://cors-server.fly.dev/";
+
+// Sample endpoint URLs for the user to test the utility with
+export const POSTMAN_GET = "postman-echo.com/get";
+export const POSTMAN_POST = "postman-echo.com/post";


### PR DESCRIPTION
Add a new `<SampleUrls/>` section to the app. Can copy a Postman URL that is displayed in the UI at the touch of a button so that it can be easily pasted into the API endpoint `<TextField/>` for testing.

This allows a new user to easily test out the app and run the requests with or without a CORS proxy to see the differences in the results.