### PR TITLE
Allow other request types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-my-api",
-  "version": "2.2.0",
-  "private": true,
+  "version": "2.3.0",
+  "private": false,
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",

--- a/src/App.css
+++ b/src/App.css
@@ -1,9 +1,0 @@
-.App {
-  margin: auto;
-  width: 95%;
-  max-width: 800px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,11 +19,13 @@ function App() {
       <UrlSubmitter proxyUrl={proxyUrl} />
       <UrlSubmitter proxyUrl={proxyUrl} />
       <UrlSubmitter proxyUrl={proxyUrl} />
-      <ProxySelector proxyUrl={proxyUrl} setProxyUrl={setProxyUrl} />
-      <RequestSelector
-        requestType={requestType}
-        setRequestType={setRequestType}
-      />
+      <Box sx={selectorWrapperStyle}>
+        <ProxySelector proxyUrl={proxyUrl} setProxyUrl={setProxyUrl} />
+        <RequestSelector
+          requestType={requestType}
+          setRequestType={setRequestType}
+        />
+      </Box>
     </Box>
   );
 }
@@ -38,4 +40,11 @@ const appStyle = {
   flexDirection: "column",
   alignItems: "center",
   justifyContent: "center",
+};
+
+const selectorWrapperStyle = {
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "space-between",
+  width: "100%",
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,16 @@
 import { useState } from "react";
+import { Box } from "@mui/material";
 import UrlSubmitter from "./components/UrlSubmitter";
 import ProxySelector from "./components/ProxySelector";
 import HeadingText from "./components/HeadingText";
 import AboutText from "./components/AboutText";
 import SampleUrls from "./components/SampleUrls";
-import "./App.css";
 
 function App() {
   const [proxyUrl, setProxyUrl] = useState("");
 
   return (
-    <div className="App">
+    <Box sx={appStyle}>
       <HeadingText />
       <AboutText />
       <SampleUrls />
@@ -18,8 +18,18 @@ function App() {
       <UrlSubmitter proxyUrl={proxyUrl} />
       <UrlSubmitter proxyUrl={proxyUrl} />
       <ProxySelector proxyUrl={proxyUrl} setProxyUrl={setProxyUrl} />
-    </div>
+    </Box>
   );
 }
 
 export default App;
+
+const appStyle = {
+  margin: "auto",
+  width: "95%",
+  maxWidth: " 800px",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { Box } from "@mui/material";
-import UrlSubmitter from "./components/UrlSubmitter";
-import ProxySelector from "./components/ProxySelector";
 import HeadingText from "./components/HeadingText";
 import AboutText from "./components/AboutText";
 import SampleUrls from "./components/SampleUrls";
+import UrlSubmitter from "./components/UrlSubmitter";
+import ProxySelector from "./components/ProxySelector";
 
 function App() {
   const [proxyUrl, setProxyUrl] = useState("");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ function App() {
         <RequestBody
           requestBody={requestBody}
           setRequestBody={setRequestBody}
+          requestType={requestType}
         />
         <RequestSelector
           requestType={requestType}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,9 +18,21 @@ function App() {
       <HeadingText />
       <AboutText />
       <SampleUrls />
-      <UrlSubmitter proxyUrl={proxyUrl} />
-      <UrlSubmitter proxyUrl={proxyUrl} />
-      <UrlSubmitter proxyUrl={proxyUrl} />
+      <UrlSubmitter
+        proxyUrl={proxyUrl}
+        requestType={requestType}
+        requestBody={requestBody}
+      />
+      <UrlSubmitter
+        proxyUrl={proxyUrl}
+        requestType={requestType}
+        requestBody={requestBody}
+      />
+      <UrlSubmitter
+        proxyUrl={proxyUrl}
+        requestType={requestType}
+        requestBody={requestBody}
+      />
       <Box sx={selectorWrapperStyle}>
         <ProxySelector proxyUrl={proxyUrl} setProxyUrl={setProxyUrl} />
         <RequestBody

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import RequestBody from "./components/RequestBody";
 
 function App() {
   const [proxyUrl, setProxyUrl] = useState("");
-  const [requestType, setRequestType] = useState("get");
+  const [requestType, setRequestType] = useState("GET");
   const [requestBody, setRequestBody] = useState("");
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,12 @@ import SampleUrls from "./components/SampleUrls";
 import UrlSubmitter from "./components/UrlSubmitter";
 import ProxySelector from "./components/ProxySelector";
 import RequestSelector from "./components/RequestSelector";
+import RequestBody from "./components/RequestBody";
 
 function App() {
   const [proxyUrl, setProxyUrl] = useState("");
   const [requestType, setRequestType] = useState("get");
+  const [requestBody, setRequestBody] = useState("");
 
   return (
     <Box sx={appStyle}>
@@ -21,6 +23,10 @@ function App() {
       <UrlSubmitter proxyUrl={proxyUrl} />
       <Box sx={selectorWrapperStyle}>
         <ProxySelector proxyUrl={proxyUrl} setProxyUrl={setProxyUrl} />
+        <RequestBody
+          requestBody={requestBody}
+          setRequestBody={setRequestBody}
+        />
         <RequestSelector
           requestType={requestType}
           setRequestType={setRequestType}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,9 +5,11 @@ import AboutText from "./components/AboutText";
 import SampleUrls from "./components/SampleUrls";
 import UrlSubmitter from "./components/UrlSubmitter";
 import ProxySelector from "./components/ProxySelector";
+import RequestSelector from "./components/RequestSelector";
 
 function App() {
   const [proxyUrl, setProxyUrl] = useState("");
+  const [requestType, setRequestType] = useState("get");
 
   return (
     <Box sx={appStyle}>
@@ -18,6 +20,10 @@ function App() {
       <UrlSubmitter proxyUrl={proxyUrl} />
       <UrlSubmitter proxyUrl={proxyUrl} />
       <ProxySelector proxyUrl={proxyUrl} setProxyUrl={setProxyUrl} />
+      <RequestSelector
+        requestType={requestType}
+        setRequestType={setRequestType}
+      />
     </Box>
   );
 }

--- a/src/components/ProxySelector.tsx
+++ b/src/components/ProxySelector.tsx
@@ -38,4 +38,5 @@ export default ProxySelector;
 
 const radioGroupStyle = {
   margin: "20px",
+  minWidth: "100px",
 };

--- a/src/components/ProxySelector.tsx
+++ b/src/components/ProxySelector.tsx
@@ -6,9 +6,9 @@ import { FIREBASE_PROXY, FLY_PROXY } from "../util/urls";
 function ProxySelector(props: any) {
   const { proxyUrl, setProxyUrl } = props;
 
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
     setProxyUrl(event.target.value);
-  };
+  }
 
   return (
     <FormControl sx={radioGroupStyle}>

--- a/src/components/RequestBody.tsx
+++ b/src/components/RequestBody.tsx
@@ -4,16 +4,19 @@ import { TextField } from "@mui/material";
 function RequestBody(props: any) {
   const { requestBody, setRequestBody, requestType } = props;
 
+  const isGetRequest = requestType === "get";
+  const getPlaceholder = "A GET request does not have a body";
+
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     setRequestBody(event.target.value);
   }
 
   return (
     <TextField
-      label="Enter request body"
+      label={isGetRequest ? getPlaceholder : "Request body"}
       value={requestBody}
       onChange={handleChange}
-      disabled={requestType === "get"}
+      disabled={isGetRequest}
       multiline
       minRows={6}
       sx={requestBodyStyle}

--- a/src/components/RequestBody.tsx
+++ b/src/components/RequestBody.tsx
@@ -4,7 +4,7 @@ import { TextField } from "@mui/material";
 function RequestBody(props: any) {
   const { requestBody, setRequestBody, requestType } = props;
 
-  const isGetRequest = requestType === "get";
+  const isGetRequest = requestType === "GET";
   const getPlaceholder = "A GET request does not have a body";
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {

--- a/src/components/RequestBody.tsx
+++ b/src/components/RequestBody.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent } from "react";
 import { TextField } from "@mui/material";
 
 function RequestBody(props: any) {
-  const { requestBody, setRequestBody } = props;
+  const { requestBody, setRequestBody, requestType } = props;
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     setRequestBody(event.target.value);
@@ -13,6 +13,7 @@ function RequestBody(props: any) {
       label="Enter request body"
       value={requestBody}
       onChange={handleChange}
+      disabled={requestType === "get"}
       multiline
       minRows={6}
       sx={requestBodyStyle}

--- a/src/components/RequestBody.tsx
+++ b/src/components/RequestBody.tsx
@@ -1,0 +1,28 @@
+import { ChangeEvent } from "react";
+import { TextField } from "@mui/material";
+
+function RequestBody(props: any) {
+  const { requestBody, setRequestBody } = props;
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    setRequestBody(event.target.value);
+  }
+
+  return (
+    <TextField
+      label="Enter request body"
+      value={requestBody}
+      onChange={handleChange}
+      multiline
+      minRows={6}
+      sx={requestBodyStyle}
+    />
+  );
+}
+
+export default RequestBody;
+
+const requestBodyStyle = {
+  width: "100%",
+  maxWidth: "480px",
+};

--- a/src/components/RequestSelector.tsx
+++ b/src/components/RequestSelector.tsx
@@ -1,0 +1,32 @@
+import { ChangeEvent } from "react";
+import { Radio, RadioGroup } from "@mui/material";
+import { FormControlLabel, FormControl, FormLabel } from "@mui/material";
+
+function RequestSelector(props: any) {
+  const { requestType, setRequestType } = props;
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setRequestType(event.target.value);
+  };
+
+  return (
+    <FormControl sx={radioGroupStyle}>
+      <FormLabel id="request-type-options-label">Request type</FormLabel>
+      <RadioGroup
+        aria-labelledby="request-type-options-label"
+        name="request-type-options"
+        value={requestType}
+        onChange={handleChange}>
+        <FormControlLabel value={"get"} control={<Radio />} label="GET" />
+        <FormControlLabel value={"post"} control={<Radio />} label="POST" />
+        <FormControlLabel value={"put"} control={<Radio />} label="PUT" />
+      </RadioGroup>
+    </FormControl>
+  );
+}
+
+export default RequestSelector;
+
+const radioGroupStyle = {
+  margin: "20px",
+};

--- a/src/components/RequestSelector.tsx
+++ b/src/components/RequestSelector.tsx
@@ -29,4 +29,5 @@ export default RequestSelector;
 
 const radioGroupStyle = {
   margin: "20px",
+  minWidth: "100px",
 };

--- a/src/components/RequestSelector.tsx
+++ b/src/components/RequestSelector.tsx
@@ -17,9 +17,9 @@ function RequestSelector(props: any) {
         name="request-type-options"
         value={requestType}
         onChange={handleChange}>
-        <FormControlLabel value={"get"} control={<Radio />} label="GET" />
-        <FormControlLabel value={"post"} control={<Radio />} label="POST" />
-        <FormControlLabel value={"put"} control={<Radio />} label="PUT" />
+        <FormControlLabel value={"GET"} control={<Radio />} label="GET" />
+        <FormControlLabel value={"POST"} control={<Radio />} label="POST" />
+        <FormControlLabel value={"PUT"} control={<Radio />} label="PUT" />
       </RadioGroup>
     </FormControl>
   );

--- a/src/components/RequestSelector.tsx
+++ b/src/components/RequestSelector.tsx
@@ -5,9 +5,9 @@ import { FormControlLabel, FormControl, FormLabel } from "@mui/material";
 function RequestSelector(props: any) {
   const { requestType, setRequestType } = props;
 
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
     setRequestType(event.target.value);
-  };
+  }
 
   return (
     <FormControl sx={radioGroupStyle}>

--- a/src/components/UrlSubmitter.tsx
+++ b/src/components/UrlSubmitter.tsx
@@ -17,25 +17,19 @@ function UrlSubmitter(props: any) {
 
   async function submitApiUrl(event: SyntheticEvent<HTMLFormElement>) {
     event.preventDefault();
-    let response;
     try {
+      let response;
       if (requestType === "GET") {
         response = await fetch(proxyUrl + apiUrl);
       } else {
         response = await fetch(proxyUrl + apiUrl, fetchOptions);
       }
+      const jsonRes = await response.json();
+      console.log(jsonRes);
     } catch (error) {
-      console.log("Result: API fetch request has failed");
+      console.log("There was an error with the HTTP request :(");
       console.error(error);
     }
-    if (response)
-      try {
-        const jsonRes = await response.json();
-        console.log(jsonRes);
-      } catch (error) {
-        console.log("Result: API request succeeded, but failed to parse JSON");
-        console.error(error);
-      }
   }
 
   return (

--- a/src/components/UrlSubmitter.tsx
+++ b/src/components/UrlSubmitter.tsx
@@ -4,7 +4,12 @@ import { Box, TextField, Button } from "@mui/material";
 function UrlSubmitter(props: any) {
   const [apiUrl, setApiUrl] = useState("");
 
-  const { proxyUrl } = props;
+  const { proxyUrl, requestType, requestBody } = props;
+
+  const fetchOptions = {
+    method: requestType,
+    body: requestBody,
+  };
 
   function handleApiUrl(event: ChangeEvent<HTMLInputElement>): void {
     setApiUrl(event.currentTarget.value);
@@ -14,7 +19,11 @@ function UrlSubmitter(props: any) {
     event.preventDefault();
     let response;
     try {
-      response = await fetch(proxyUrl + apiUrl);
+      if (requestType === "GET") {
+        response = await fetch(proxyUrl + apiUrl);
+      } else {
+        response = await fetch(proxyUrl + apiUrl, fetchOptions);
+      }
     } catch (error) {
       console.log("Result: API fetch request has failed");
       console.error(error);


### PR DESCRIPTION
+ Add a `<RequestSelector/>` component that allows radio selection of HTTP methods in a similar fashion to `<ProxySelector/>`.
+ Add a `<RequestBody/>` component that is a multiline MUI `<TextField/>` so that the user can enter a body when making a `POST` or `PUT` request. Disable when the request type is `GET`.
+ Improve layout with these new sections in the UI.
+ Add a `requestOptions` object that includes the method type and body. Then attach when sending a request that is not `GET`.