### PR TITLE
Refactor with useContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-my-api",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": false,
   "dependencies": {
     "@emotion/react": "^11.10.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,16 +45,9 @@ function App() {
           setResponseCodeText={setResponseCodeText}
         />
         <Box sx={selectorWrapperStyle}>
-          <ProxySelector proxyUrl={proxyUrl} setProxyUrl={setProxyUrl} />
-          <RequestBody
-            requestBody={requestBody}
-            setRequestBody={setRequestBody}
-            requestType={requestType}
-          />
-          <RequestSelector
-            requestType={requestType}
-            setRequestType={setRequestType}
-          />
+          <ProxySelector setProxyUrl={setProxyUrl} />
+          <RequestBody setRequestBody={setRequestBody} />
+          <RequestSelector setRequestType={setRequestType} />
         </Box>
         <ResponseAlerts
           response={response}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
   const [response, setResponse] = useState({});
   const [responseCode, setResponseCode] = useState(0);
   const [responseCodeText, setResponseCodeText] = useState("");
-  const globalContext = {
+  const urlSubContext = {
     proxyUrl,
     requestType,
     requestBody,
@@ -27,7 +27,7 @@ function App() {
   };
 
   return (
-    <UrlSubContext.Provider value={globalContext}>
+    <UrlSubContext.Provider value={urlSubContext}>
       <Box sx={appStyle}>
         <HeadingText />
         <AboutText />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,21 +32,9 @@ function App() {
         <HeadingText />
         <AboutText />
         <SampleUrls />
-        <UrlSubmitter
-          setResponse={setResponse}
-          setResponseCode={setResponseCode}
-          setResponseCodeText={setResponseCodeText}
-        />
-        <UrlSubmitter
-          setResponse={setResponse}
-          setResponseCode={setResponseCode}
-          setResponseCodeText={setResponseCodeText}
-        />
-        <UrlSubmitter
-          setResponse={setResponse}
-          setResponseCode={setResponseCode}
-          setResponseCodeText={setResponseCodeText}
-        />
+        <UrlSubmitter />
+        <UrlSubmitter />
+        <UrlSubmitter />
         <Box sx={selectorWrapperStyle}>
           <ProxySelector setProxyUrl={setProxyUrl} />
           <RequestBody setRequestBody={setRequestBody} />
@@ -54,11 +42,8 @@ function App() {
         </Box>
         <ResponseAlerts
           response={response}
-          setResponse={setResponse}
           responseCode={responseCode}
-          setResponseCode={setResponseCode}
           responseCodeText={responseCodeText}
-          setResponseCodeText={setResponseCodeText}
         />
       </Box>
     </GlobalContext.Provider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Box } from "@mui/material";
-import { GlobalContext } from "./util/GlobalContext";
+import { UrlSubContext } from "./util/GlobalContext";
 import HeadingText from "./components/HeadingText";
 import AboutText from "./components/AboutText";
 import SampleUrls from "./components/SampleUrls";
@@ -27,7 +27,7 @@ function App() {
   };
 
   return (
-    <GlobalContext.Provider value={globalContext}>
+    <UrlSubContext.Provider value={globalContext}>
       <Box sx={appStyle}>
         <HeadingText />
         <AboutText />
@@ -46,7 +46,7 @@ function App() {
           responseCodeText={responseCodeText}
         />
       </Box>
-    </GlobalContext.Provider>
+    </UrlSubContext.Provider>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Box } from "@mui/material";
+import { GlobalContext } from "./util/GlobalContext";
 import HeadingText from "./components/HeadingText";
 import AboutText from "./components/AboutText";
 import SampleUrls from "./components/SampleUrls";
@@ -16,57 +17,55 @@ function App() {
   const [response, setResponse] = useState({});
   const [responseCode, setResponseCode] = useState(0);
   const [responseCodeText, setResponseCodeText] = useState("");
+  const globalContext = {
+    proxyUrl,
+    requestType,
+    requestBody,
+  };
 
   return (
-    <Box sx={appStyle}>
-      <HeadingText />
-      <AboutText />
-      <SampleUrls />
-      <UrlSubmitter
-        proxyUrl={proxyUrl}
-        requestType={requestType}
-        requestBody={requestBody}
-        setResponse={setResponse}
-        setResponseCode={setResponseCode}
-        setResponseCodeText={setResponseCodeText}
-      />
-      <UrlSubmitter
-        proxyUrl={proxyUrl}
-        requestType={requestType}
-        requestBody={requestBody}
-        setResponse={setResponse}
-        setResponseCode={setResponseCode}
-        setResponseCodeText={setResponseCodeText}
-      />
-      <UrlSubmitter
-        proxyUrl={proxyUrl}
-        requestType={requestType}
-        requestBody={requestBody}
-        setResponse={setResponse}
-        setResponseCode={setResponseCode}
-        setResponseCodeText={setResponseCodeText}
-      />
-      <Box sx={selectorWrapperStyle}>
-        <ProxySelector proxyUrl={proxyUrl} setProxyUrl={setProxyUrl} />
-        <RequestBody
-          requestBody={requestBody}
-          setRequestBody={setRequestBody}
-          requestType={requestType}
+    <GlobalContext.Provider value={globalContext}>
+      <Box sx={appStyle}>
+        <HeadingText />
+        <AboutText />
+        <SampleUrls />
+        <UrlSubmitter
+          setResponse={setResponse}
+          setResponseCode={setResponseCode}
+          setResponseCodeText={setResponseCodeText}
         />
-        <RequestSelector
-          requestType={requestType}
-          setRequestType={setRequestType}
+        <UrlSubmitter
+          setResponse={setResponse}
+          setResponseCode={setResponseCode}
+          setResponseCodeText={setResponseCodeText}
+        />
+        <UrlSubmitter
+          setResponse={setResponse}
+          setResponseCode={setResponseCode}
+          setResponseCodeText={setResponseCodeText}
+        />
+        <Box sx={selectorWrapperStyle}>
+          <ProxySelector proxyUrl={proxyUrl} setProxyUrl={setProxyUrl} />
+          <RequestBody
+            requestBody={requestBody}
+            setRequestBody={setRequestBody}
+            requestType={requestType}
+          />
+          <RequestSelector
+            requestType={requestType}
+            setRequestType={setRequestType}
+          />
+        </Box>
+        <ResponseAlerts
+          response={response}
+          setResponse={setResponse}
+          responseCode={responseCode}
+          setResponseCode={setResponseCode}
+          responseCodeText={responseCodeText}
+          setResponseCodeText={setResponseCodeText}
         />
       </Box>
-      <ResponseAlerts
-        response={response}
-        setResponse={setResponse}
-        responseCode={responseCode}
-        setResponseCode={setResponseCode}
-        responseCodeText={responseCodeText}
-        setResponseCodeText={setResponseCodeText}
-      />
-    </Box>
+    </GlobalContext.Provider>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,9 @@ function App() {
     proxyUrl,
     requestType,
     requestBody,
+    setResponse,
+    setResponseCode,
+    setResponseCodeText,
   };
 
   return (

--- a/src/components/ProxySelector.tsx
+++ b/src/components/ProxySelector.tsx
@@ -2,11 +2,11 @@ import { useContext, ChangeEvent } from "react";
 import { Radio, RadioGroup } from "@mui/material";
 import { FormControlLabel, FormControl, FormLabel } from "@mui/material";
 import { FIREBASE_PROXY, FLY_PROXY } from "../util/urls";
-import { GlobalContext } from "../util/GlobalContext";
+import { UrlSubContext } from "../util/GlobalContext";
 
 function ProxySelector(props: any) {
   const { setProxyUrl } = props;
-  const { proxyUrl } = useContext(GlobalContext);
+  const { proxyUrl } = useContext(UrlSubContext);
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     setProxyUrl(event.target.value);

--- a/src/components/ProxySelector.tsx
+++ b/src/components/ProxySelector.tsx
@@ -1,10 +1,12 @@
-import { ChangeEvent } from "react";
+import { useContext, ChangeEvent } from "react";
 import { Radio, RadioGroup } from "@mui/material";
 import { FormControlLabel, FormControl, FormLabel } from "@mui/material";
 import { FIREBASE_PROXY, FLY_PROXY } from "../util/urls";
+import { GlobalContext } from "../util/GlobalContext";
 
 function ProxySelector(props: any) {
-  const { proxyUrl, setProxyUrl } = props;
+  const { setProxyUrl } = props;
+  const { proxyUrl } = useContext(GlobalContext);
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     setProxyUrl(event.target.value);

--- a/src/components/RequestBody.tsx
+++ b/src/components/RequestBody.tsx
@@ -1,10 +1,10 @@
 import { useContext, ChangeEvent } from "react";
 import { TextField } from "@mui/material";
-import { GlobalContext } from "../util/GlobalContext";
+import { UrlSubContext } from "../util/GlobalContext";
 
 function RequestBody(props: any) {
   const { setRequestBody } = props;
-  const { requestBody, requestType } = useContext(GlobalContext);
+  const { requestBody, requestType } = useContext(UrlSubContext);
 
   const isGetRequest = requestType === "GET";
   const getPlaceholder = "A GET request does not have a body";

--- a/src/components/RequestBody.tsx
+++ b/src/components/RequestBody.tsx
@@ -1,8 +1,10 @@
-import { ChangeEvent } from "react";
+import { useContext, ChangeEvent } from "react";
 import { TextField } from "@mui/material";
+import { GlobalContext } from "../util/GlobalContext";
 
 function RequestBody(props: any) {
-  const { requestBody, setRequestBody, requestType } = props;
+  const { setRequestBody } = props;
+  const { requestBody, requestType } = useContext(GlobalContext);
 
   const isGetRequest = requestType === "GET";
   const getPlaceholder = "A GET request does not have a body";

--- a/src/components/RequestSelector.tsx
+++ b/src/components/RequestSelector.tsx
@@ -1,9 +1,11 @@
-import { ChangeEvent } from "react";
+import { useContext, ChangeEvent } from "react";
 import { Radio, RadioGroup } from "@mui/material";
 import { FormControlLabel, FormControl, FormLabel } from "@mui/material";
+import { GlobalContext } from "../util/GlobalContext";
 
 function RequestSelector(props: any) {
-  const { requestType, setRequestType } = props;
+  const { setRequestType } = props;
+  const { requestType } = useContext(GlobalContext);
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     setRequestType(event.target.value);

--- a/src/components/RequestSelector.tsx
+++ b/src/components/RequestSelector.tsx
@@ -1,11 +1,11 @@
 import { useContext, ChangeEvent } from "react";
 import { Radio, RadioGroup } from "@mui/material";
 import { FormControlLabel, FormControl, FormLabel } from "@mui/material";
-import { GlobalContext } from "../util/GlobalContext";
+import { UrlSubContext } from "../util/GlobalContext";
 
 function RequestSelector(props: any) {
   const { setRequestType } = props;
-  const { requestType } = useContext(GlobalContext);
+  const { requestType } = useContext(UrlSubContext);
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     setRequestType(event.target.value);

--- a/src/components/ResponseAlerts.tsx
+++ b/src/components/ResponseAlerts.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useContext, useRef } from "react";
 import { Snackbar, Alert, AlertTitle, AlertColor } from "@mui/material";
-import { GlobalContext } from "../util/GlobalContext";
+import { UrlSubContext } from "../util/GlobalContext";
 
 function ResponseAlerts(props: any) {
   const [showResponse, setShowResponse] = useState(false);
@@ -8,7 +8,7 @@ function ResponseAlerts(props: any) {
 
   const { response, responseCode, responseCodeText } = props;
   const { setResponse, setResponseCode, setResponseCodeText } =
-    useContext(GlobalContext);
+    useContext(UrlSubContext);
 
   const vertical = "top";
   const horizontal = "center";

--- a/src/components/ResponseAlerts.tsx
+++ b/src/components/ResponseAlerts.tsx
@@ -1,12 +1,15 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useContext, useRef } from "react";
 import { Snackbar, Alert, AlertTitle, AlertColor } from "@mui/material";
+import { GlobalContext } from "../util/GlobalContext";
 
 function ResponseAlerts(props: any) {
   const [showResponse, setShowResponse] = useState(false);
   const alertStatus = useRef<AlertColor>("info");
 
-  const { response, setResponse, responseCode, setResponseCode } = props;
-  const { responseCodeText, setResponseCodeText } = props;
+  const { response, responseCode, responseCodeText } = props;
+  const { setResponse, setResponseCode, setResponseCodeText } =
+    useContext(GlobalContext);
+
   const vertical = "top";
   const horizontal = "center";
 

--- a/src/components/UrlSubmitter.tsx
+++ b/src/components/UrlSubmitter.tsx
@@ -1,6 +1,6 @@
 import { useState, useContext, ChangeEvent, SyntheticEvent } from "react";
 import { Box, TextField, Button } from "@mui/material";
-import { GlobalContext } from "../util/GlobalContext";
+import { UrlSubContext } from "../util/GlobalContext";
 
 function UrlSubmitter() {
   const [apiUrl, setApiUrl] = useState("");
@@ -12,7 +12,7 @@ function UrlSubmitter() {
     setResponse,
     setResponseCode,
     setResponseCodeText,
-  } = useContext(GlobalContext);
+  } = useContext(UrlSubContext);
 
   const fetchOptions = {
     method: requestType,

--- a/src/components/UrlSubmitter.tsx
+++ b/src/components/UrlSubmitter.tsx
@@ -2,11 +2,17 @@ import { useState, useContext, ChangeEvent, SyntheticEvent } from "react";
 import { Box, TextField, Button } from "@mui/material";
 import { GlobalContext } from "../util/GlobalContext";
 
-function UrlSubmitter(props: any) {
+function UrlSubmitter() {
   const [apiUrl, setApiUrl] = useState("");
 
-  const { proxyUrl, requestType, requestBody } = useContext(GlobalContext);
-  const { setResponse, setResponseCode, setResponseCodeText } = props;
+  const {
+    proxyUrl,
+    requestType,
+    requestBody,
+    setResponse,
+    setResponseCode,
+    setResponseCodeText,
+  } = useContext(GlobalContext);
 
   const fetchOptions = {
     method: requestType,

--- a/src/components/UrlSubmitter.tsx
+++ b/src/components/UrlSubmitter.tsx
@@ -1,10 +1,11 @@
-import { useState, ChangeEvent, SyntheticEvent } from "react";
+import { useState, useContext, ChangeEvent, SyntheticEvent } from "react";
 import { Box, TextField, Button } from "@mui/material";
+import { GlobalContext } from "../util/GlobalContext";
 
 function UrlSubmitter(props: any) {
   const [apiUrl, setApiUrl] = useState("");
 
-  const { proxyUrl, requestType, requestBody } = props;
+  const { proxyUrl, requestType, requestBody } = useContext(GlobalContext);
   const { setResponse, setResponseCode, setResponseCodeText } = props;
 
   const fetchOptions = {

--- a/src/util/GlobalContext.ts
+++ b/src/util/GlobalContext.ts
@@ -5,9 +5,9 @@ export const GlobalContext = createContext<ContextProps>({
   proxyUrl: "",
   requestType: "GET",
   requestBody: "",
-  setResponse: () => <object>{},
-  setResponseCode: () => <number>{},
-  setResponseCodeText: () => <string>{},
+  setResponse: () => <object>{}, // eslint-disable-line
+  setResponseCode: () => <number>{}, // eslint-disable-line
+  setResponseCodeText: () => <string>{}, // eslint-disable-line
 });
 
 interface ContextProps {

--- a/src/util/GlobalContext.ts
+++ b/src/util/GlobalContext.ts
@@ -1,7 +1,20 @@
 import { createContext } from "react";
+import { Dispatch, SetStateAction } from "react";
 
-export const GlobalContext = createContext({
+export const GlobalContext = createContext<ContextProps>({
   proxyUrl: "",
   requestType: "GET",
   requestBody: "",
+  setResponse: () => <object>{},
+  setResponseCode: () => <number>{},
+  setResponseCodeText: () => <string>{},
 });
+
+interface ContextProps {
+  proxyUrl: string;
+  requestType: string;
+  requestBody: string;
+  setResponse: Dispatch<SetStateAction<object>>;
+  setResponseCode: Dispatch<SetStateAction<number>>;
+  setResponseCodeText: Dispatch<SetStateAction<string>>;
+}

--- a/src/util/GlobalContext.ts
+++ b/src/util/GlobalContext.ts
@@ -1,7 +1,7 @@
 import { createContext } from "react";
 import { Dispatch, SetStateAction } from "react";
 
-export const GlobalContext = createContext<ContextProps>({
+export const UrlSubContext = createContext<ContextProps>({
   proxyUrl: "",
   requestType: "GET",
   requestBody: "",

--- a/src/util/GlobalContext.ts
+++ b/src/util/GlobalContext.ts
@@ -1,7 +1,7 @@
 import { createContext } from "react";
 import { Dispatch, SetStateAction } from "react";
 
-export const UrlSubContext = createContext<ContextProps>({
+export const UrlSubContext = createContext<UrlSubState>({
   proxyUrl: "",
   requestType: "GET",
   requestBody: "",
@@ -10,7 +10,7 @@ export const UrlSubContext = createContext<ContextProps>({
   setResponseCodeText: () => <string>{}, // eslint-disable-line
 });
 
-interface ContextProps {
+interface UrlSubState {
   proxyUrl: string;
   requestType: string;
   requestBody: string;

--- a/src/util/GlobalContext.ts
+++ b/src/util/GlobalContext.ts
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+export const GlobalContext = createContext({
+  proxyUrl: "",
+  requestType: "GET",
+  requestBody: "",
+});


### PR DESCRIPTION
Created a new Context object called `UrlSubContext` and pass in the state variables (including setters) that were previously passed to `<UrlSubmitter/>` via props. Then extract the state from Context within the `UrlSubmitter` component instead of props. Also used this Context in other components where applicable.

The reason for this refactoring is to reduce code duplication whereby the same `props` were passed down to multiple components from `<App/>`. See file diff for the extent of this.