### PR TITLE
Add loading spinner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-my-api",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "private": false,
   "dependencies": {
     "@emotion/react": "^11.10.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ function App() {
     proxyUrl,
     requestType,
     requestBody,
+    spinnerOn,
     setResponse,
     setResponseCode,
     setResponseCodeText,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ function App() {
   const [response, setResponse] = useState({});
   const [responseCode, setResponseCode] = useState(0);
   const [responseCodeText, setResponseCodeText] = useState("");
+  const [spinnerOn, setSpinnerOn] = useState(false);
   const urlSubContext = {
     proxyUrl,
     requestType,
@@ -45,7 +46,7 @@ function App() {
           responseCode={responseCode}
           responseCodeText={responseCodeText}
         />
-        <CircularProgress sx={spinnerStyle} />
+        {spinnerOn ? <CircularProgress sx={spinnerStyle} /> : null}
       </Box>
     </UrlSubContext.Provider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Box } from "@mui/material";
+import { Box, CircularProgress } from "@mui/material";
 import { UrlSubContext } from "./util/GlobalContext";
 import HeadingText from "./components/HeadingText";
 import AboutText from "./components/AboutText";
@@ -45,6 +45,7 @@ function App() {
           responseCode={responseCode}
           responseCodeText={responseCodeText}
         />
+        <CircularProgress sx={spinnerStyle} />
       </Box>
     </UrlSubContext.Provider>
   );
@@ -67,4 +68,10 @@ const selectorWrapperStyle = {
   flexDirection: "row",
   justifyContent: "space-between",
   width: "100%",
+};
+
+const spinnerStyle = {
+  position: "absolute",
+  left: "50%",
+  top: "50%",
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ function App() {
     setResponse,
     setResponseCode,
     setResponseCodeText,
+    setSpinnerOn,
   };
 
   return (

--- a/src/components/UrlSubmitter.tsx
+++ b/src/components/UrlSubmitter.tsx
@@ -9,6 +9,7 @@ function UrlSubmitter() {
     proxyUrl,
     requestType,
     requestBody,
+    spinnerOn,
     setResponse,
     setResponseCode,
     setResponseCodeText,
@@ -54,7 +55,7 @@ function UrlSubmitter() {
         onChange={handleApiUrl}
         sx={fieldStyle}
       />
-      <Button variant="outlined" type="submit">
+      <Button variant="outlined" type="submit" disabled={spinnerOn}>
         Run
       </Button>
     </Box>

--- a/src/components/UrlSubmitter.tsx
+++ b/src/components/UrlSubmitter.tsx
@@ -12,6 +12,7 @@ function UrlSubmitter() {
     setResponse,
     setResponseCode,
     setResponseCodeText,
+    setSpinnerOn,
   } = useContext(UrlSubContext);
 
   const fetchOptions = {
@@ -25,6 +26,7 @@ function UrlSubmitter() {
 
   async function submitApiUrl(event: SyntheticEvent<HTMLFormElement>) {
     event.preventDefault();
+    setSpinnerOn(true);
     try {
       let res;
       if (requestType === "GET") res = await fetch(proxyUrl + apiUrl);
@@ -41,6 +43,7 @@ function UrlSubmitter() {
       setResponseCodeText("Unknown Error");
       console.log(error);
     }
+    setSpinnerOn(false);
   }
 
   return (

--- a/src/components/UrlSubmitter.tsx
+++ b/src/components/UrlSubmitter.tsx
@@ -27,11 +27,8 @@ function UrlSubmitter() {
     event.preventDefault();
     try {
       let res;
-      if (requestType === "GET") {
-        res = await fetch(proxyUrl + apiUrl);
-      } else {
-        res = await fetch(proxyUrl + apiUrl, fetchOptions);
-      }
+      if (requestType === "GET") res = await fetch(proxyUrl + apiUrl);
+      else res = await fetch(proxyUrl + apiUrl, fetchOptions);
       setResponseCode(res.status);
       setResponseCodeText(res.statusText);
       if (res.status === 200) {

--- a/src/util/GlobalContext.ts
+++ b/src/util/GlobalContext.ts
@@ -5,6 +5,7 @@ export const UrlSubContext = createContext<UrlSubState>({
   proxyUrl: "",
   requestType: "GET",
   requestBody: "",
+  spinnerOn: false,
   setResponse: () => <object>{}, // eslint-disable-line
   setResponseCode: () => <number>{}, // eslint-disable-line
   setResponseCodeText: () => <string>{}, // eslint-disable-line
@@ -15,6 +16,7 @@ interface UrlSubState {
   proxyUrl: string;
   requestType: string;
   requestBody: string;
+  spinnerOn: boolean;
   setResponse: Dispatch<SetStateAction<object>>;
   setResponseCode: Dispatch<SetStateAction<number>>;
   setResponseCodeText: Dispatch<SetStateAction<string>>;

--- a/src/util/GlobalContext.ts
+++ b/src/util/GlobalContext.ts
@@ -8,6 +8,7 @@ export const UrlSubContext = createContext<UrlSubState>({
   setResponse: () => <object>{}, // eslint-disable-line
   setResponseCode: () => <number>{}, // eslint-disable-line
   setResponseCodeText: () => <string>{}, // eslint-disable-line
+  setSpinnerOn: () => <boolean>{}, // eslint-disable-line
 });
 
 interface UrlSubState {
@@ -17,4 +18,5 @@ interface UrlSubState {
   setResponse: Dispatch<SetStateAction<object>>;
   setResponseCode: Dispatch<SetStateAction<number>>;
   setResponseCodeText: Dispatch<SetStateAction<string>>;
+  setSpinnerOn: Dispatch<SetStateAction<boolean>>;
 }


### PR DESCRIPTION
+ Added a loading spinner from the Material UI library that gets displayed whenever an API call is being made.
+ Disable the `RUN` buttons associated with each `<UrlSubmitter/>` whilst an API request is in progress so that multiple concurrent calls are not possible as this can result in an error.