### PR TITLE
Fix alert bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-my-api",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": false,
   "dependencies": {
     "@emotion/react": "^11.10.5",

--- a/src/components/ResponseAlerts.tsx
+++ b/src/components/ResponseAlerts.tsx
@@ -28,15 +28,10 @@ function ResponseAlerts(props: any) {
     }
 
     const codeCategory = Math.floor(responseCode / 100);
-    if (codeCategory === 2) {
-      setAlertStatus("success"); // HTTP code 200 range
-    } else if (codeCategory === 4) {
-      setAlertStatus("warning"); // HTTP code 400 range
-    } else if (codeCategory === 5) {
-      setAlertStatus("error"); // HTTP code 500 range
-    } else {
-      setAlertStatus("info");
-    }
+    if (codeCategory === 2) setAlertStatus("success"); // HTTP code 200 range
+    else if (codeCategory === 4) setAlertStatus("warning"); // 400 range
+    else if (codeCategory === 5) setAlertStatus("error"); // 500 range
+    else setAlertStatus("info");
   }, [responseCode]);
 
   return (

--- a/src/components/ResponseAlerts.tsx
+++ b/src/components/ResponseAlerts.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect, useContext, useRef } from "react";
-import { Snackbar, Alert, AlertTitle, AlertColor } from "@mui/material";
+import { useState, useEffect, useContext } from "react";
+import { Snackbar, Alert, AlertTitle } from "@mui/material";
 import { UrlSubContext } from "../util/GlobalContext";
 
 function ResponseAlerts(props: any) {
   const [showResponse, setShowResponse] = useState(false);
-  const alertStatus = useRef<AlertColor>("info");
+  const [alertStatus, setAlertStatus] = useState<any>("info");
 
   const { response, responseCode, responseCodeText } = props;
   const { setResponse, setResponseCode, setResponseCodeText } =
@@ -29,13 +29,13 @@ function ResponseAlerts(props: any) {
 
     const codeCategory = Math.floor(responseCode / 100);
     if (codeCategory === 2) {
-      alertStatus.current = "success"; // HTTP code 200 range
+      setAlertStatus("success"); // HTTP code 200 range
     } else if (codeCategory === 4) {
-      alertStatus.current = "warning"; // HTTP code 400 range
+      setAlertStatus("warning"); // HTTP code 400 range
     } else if (codeCategory === 5) {
-      alertStatus.current = "error"; // HTTP code 500 range
+      setAlertStatus("error"); // HTTP code 500 range
     } else {
-      alertStatus.current = "info";
+      setAlertStatus("info");
     }
   }, [responseCode]);
 
@@ -44,7 +44,7 @@ function ResponseAlerts(props: any) {
       open={showResponse}
       onClose={handleClose}
       anchorOrigin={{ vertical, horizontal }}>
-      <Alert severity={alertStatus.current} variant="filled" sx={alertStyle}>
+      <Alert severity={alertStatus} variant="filled" sx={alertStyle}>
         {responseCode && (
           <AlertTitle>
             Status: {code} {responseCodeText}

--- a/src/components/ResponseAlerts.tsx
+++ b/src/components/ResponseAlerts.tsx
@@ -12,6 +12,7 @@ function ResponseAlerts(props: any) {
 
   const vertical = "top";
   const horizontal = "center";
+  const code = responseCode === 550 ? "" : responseCode;
 
   // Reset all state on close.
   function handleClose() {
@@ -46,7 +47,7 @@ function ResponseAlerts(props: any) {
       <Alert severity={alertStatus.current} variant="filled" sx={alertStyle}>
         {responseCode && (
           <AlertTitle>
-            Status: {responseCode} {responseCodeText}
+            Status: {code} {responseCodeText}
           </AlertTitle>
         )}
         {

--- a/src/components/UrlSubmitter.tsx
+++ b/src/components/UrlSubmitter.tsx
@@ -39,9 +39,11 @@ function UrlSubmitter() {
         setResponse(jsonRes);
         console.log(jsonRes);
       }
-    } catch (error) {
+    } catch (error: any) {
       setResponseCode(550);
-      setResponseCodeText("Unknown Server Error");
+      if (error.toString().includes("SyntaxError"))
+        setResponseCodeText("JSON not returned from server");
+      else setResponseCodeText("Unknown Server Error");
       console.log(error);
     }
     setSpinnerOn(false);

--- a/src/components/UrlSubmitter.tsx
+++ b/src/components/UrlSubmitter.tsx
@@ -41,7 +41,7 @@ function UrlSubmitter() {
       }
     } catch (error) {
       setResponseCode(550);
-      setResponseCodeText("Unknown Error");
+      setResponseCodeText("Unknown Server Error");
       console.log(error);
     }
     setSpinnerOn(false);


### PR DESCRIPTION
- Fix bug relating to the error code displayed in the alert. Had displayed a code `550` which does not exist, so mention of code number was removed and replaced with text only.
- Fix bug relating to error code state not updating due to incorrect use of `useRef`. Replaced with `useState` instead. 
- Improve error handling by displaying a different message when the response does not contain any JSON to parse.
- Some minor refactoring of a conditional statement.